### PR TITLE
kernel: A few changes to print()

### DIFF
--- a/kernel/lib/print.c
+++ b/kernel/lib/print.c
@@ -1,21 +1,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <dev/char/serial.h>
+#include <lib/libc.h>
 #include <lib/lock.h>
 #include <lib/print.h>
 
-static const char *base_digits = "0123456789abcdef";
+static const char *base_digits_lowercase = "0123456789abcdef";
+static const char *base_digits_uppercase = "0123456789ABCDEF";
 
 static inline void print_char(char *buffer, size_t size, size_t *offset, char ch) {
     if (*offset < size - 1) {
         buffer[(*offset)++] = ch;
-    }
-    buffer[*offset] = 0;
-}
-
-static inline void print_str(char *buffer, size_t size, size_t *offset, const char *str) {
-    while (*offset < size - 1 && *str) {
-        buffer[(*offset)++] = *str++;
     }
     buffer[*offset] = 0;
 }
@@ -28,70 +23,85 @@ static inline void print_nstr(char *buffer, size_t size, size_t *offset, const c
     buffer[*offset] = 0;
 }
 
-static void print_int(char *buffer, size_t size, size_t *offset, int64_t value) {
+#define MAX_INT_WIDTH 64
+
+static void print_uint(char *buffer, size_t size, size_t *offset, uint64_t value,
+                       int base, const char *prefix, size_t field_len, char pad,
+                       bool left_justify, const char *digits_set) {
+    size_t prefix_len = strlen(prefix);
+
+    char temp_buffer[MAX_INT_WIDTH];
+
+    size_t start = MAX_INT_WIDTH;
     if (!value) {
-        print_char(buffer, size, offset, '0');
-        return;
+        temp_buffer[--start] = '0';
+    }
+    while (value > 0) {
+        temp_buffer[--start] = digits_set[value % base];
+        value = value / base;
     }
 
-    int i;
-    char temp_buffer[21] = {0};
-    bool sign = value < 0;
+    size_t len = MAX_INT_WIDTH - start + prefix_len;
+    size_t to_pad = len < field_len ? field_len - len : 0;
 
-    if (sign) {
-        value = -value;
+    if (pad == '0') {
+        print_nstr(buffer, size, offset, prefix, prefix_len);
     }
 
-    for (i = 19; value; i--) {
-        temp_buffer[i] = (value % 10) + '0';
-        value = value / 10;
+    for (size_t i = 0; pad != '\0' && !left_justify && i < to_pad; ++i) {
+        print_char(buffer, size, offset, pad);
     }
 
-    if (sign) {
-        temp_buffer[i] = '-';
+    if (pad != '0') {
+        print_nstr(buffer, size, offset, prefix, prefix_len);
+    }
+
+    print_nstr(buffer, size, offset, temp_buffer + start, MAX_INT_WIDTH - start);
+
+    for (size_t i = 0; pad != '\0' && left_justify && i < to_pad; ++i) {
+        print_char(buffer, size, offset, pad);
+    }
+}
+
+static void print_int(char *buffer, size_t size, size_t *offset, int64_t value,
+                      int base, const char *negative_prefix,
+                      const char *positive_prefix, size_t field_len, char pad,
+                      bool left_justify, const char *digits_set) {
+    uint64_t modulus;
+    const char *prefix;
+
+    if (value == INT64_MIN) {
+        prefix = negative_prefix;
+        modulus = (uint64_t)INT64_MAX + 1;
+    } else if (value < 0) {
+        prefix = negative_prefix;
+        modulus = -value;
     } else {
-        i++;
+        prefix = positive_prefix;
+        modulus = value;
     }
 
-    print_str(buffer, size, offset, temp_buffer + i);
+    print_uint(buffer, size, offset, modulus, base, prefix, field_len, pad,
+               left_justify, digits_set);
 }
 
-static void print_uint(char *buffer, size_t size, size_t *offset, uint64_t value) {
-    if (!value) {
-        print_char(buffer, size, offset, '0');
-        return;
+static void print_nstr_pad(char *buffer, size_t size, size_t *offset,
+                           const char *str, size_t len, size_t field_len,
+                           char pad, bool left_justify) {
+    unsigned int to_pad = len < field_len ? field_len - len : 0;
+    for (size_t i = 0; !left_justify && i < to_pad; ++i) {
+        print_char(buffer, size, offset, pad);
     }
 
-    int i;
-    char temp_buffer[21] = {0};
+    print_nstr(buffer, size, offset, str, len);
 
-    for (i = 19; value; i--) {
-        temp_buffer[i] = (value % 10) + '0';
-        value = value / 10;
+    for (size_t i = 0; left_justify && i < to_pad; ++i) {
+        print_char(buffer, size, offset, pad);
     }
-
-    i++;
-    print_str(buffer, size, offset, temp_buffer + i);
 }
 
-static void print_hex(char *buffer, size_t size, size_t *offset, uint64_t value) {
-    if (!value) {
-        print_str(buffer, size, offset, "0x0");
-        return;
-    }
-
-    int i;
-    char temp_buffer[17] = {0};
-
-    for (i = 15; value; i--) {
-        temp_buffer[i] = base_digits[value % 16];
-        value = value / 16;
-    }
-
-    i++;
-    print_str(buffer, size, offset, "0x");
-    print_str(buffer, size, offset, temp_buffer + i);
-}
+#define NULL_REPR "(null)"
+#define NULL_REPR_LEN 6
 
 size_t vsnprint(char *buffer, size_t size, const char *fmt, va_list args) {
     size_t offset = 0;
@@ -106,31 +116,63 @@ size_t vsnprint(char *buffer, size_t size, const char *fmt, va_list args) {
         }
 
         bool long_arg = false;
+        size_t field_len = 0;
+        bool dash_flag = false;
+        bool zero_flag = false;
+        bool plus_flag = false;
+        bool space_flag = false;
+        bool hash_flag = false;
 
 parse_flags:
         char ch = *fmt++;
+        char pad = (zero_flag && !dash_flag) ? '0' : ' ';
+        bool left_justify = dash_flag;
 
         switch (ch) {
+            case '-':
+                dash_flag = true;
+                goto parse_flags;
+            case '0':
+                zero_flag = true;
+                goto parse_flags;
+            case ' ':
+                space_flag = true;
+                goto parse_flags;
+            case '+':
+                plus_flag = true;
+                goto parse_flags;
+            case '#':
+                hash_flag = true;
+                goto parse_flags;
+            case '1'...'9': {
+                field_len = ch - '0';
+                while ('0' <= *fmt && *fmt <= '9') {
+                    ch = *fmt++;
+                    field_len = field_len * 10 + ch - '0';
+                }
+                goto parse_flags;
+            }
             case 'l':
                 long_arg = true;
                 goto parse_flags;
-            case 's': {
-                char *str = va_arg(args, char *);
-                if (str) {
-                    print_str(buffer, size, &offset, str);
-                } else {
-                    print_str(buffer, size, &offset, "(null)");
-                }
-                break;
-            }
+            case 's':
             case 'S': {
                 char *str = va_arg(args, char *);
-                size_t len = va_arg(args, size_t);
-                if (str) {
-                    print_nstr(buffer, size, &offset, str, len);
+                size_t len;
+                if (str == NULL) {
+                    str = NULL_REPR;
+                    len = NULL_REPR_LEN;
+                } if (ch == 's') {
+                    len = strlen(str);
                 } else {
-                    print_str(buffer, size, &offset, "(null)");
+                    len = va_arg(args, size_t);
                 }
+                if (len == 0 && space_flag) {
+                    str = " ";
+                    len = 1;
+                }
+                print_nstr_pad(buffer, size, &offset, str, len, field_len, ' ',
+                               left_justify);
                 break;
             }
             case 'c': {
@@ -138,6 +180,9 @@ parse_flags:
                 print_char(buffer, size, &offset, c);
                 break;
             }
+            case '%':
+                print_char(buffer, size, &offset, '%');
+                break;
             case 'i':
             case 'd': {
                 int64_t value;
@@ -146,7 +191,14 @@ parse_flags:
                 } else {
                     value = va_arg(args, int32_t);
                 }
-                print_int(buffer, size, &offset, value);
+                const char *pos_prefix = "";
+                if (plus_flag) {
+                    pos_prefix = "+";
+                } else if (space_flag) {
+                    pos_prefix = " ";
+                }
+                print_int(buffer, size, &offset, value, 10, "-", pos_prefix, field_len,
+                          pad, left_justify, base_digits_lowercase);
                 break;
             }
             case 'u': {
@@ -156,17 +208,56 @@ parse_flags:
                 } else {
                     value = va_arg(args, uint32_t);
                 }
-                print_uint(buffer, size, &offset, value);
+                print_uint(buffer, size, &offset, value, 10, "", field_len, pad,
+                           left_justify, base_digits_lowercase);
                 break;
             }
-            case 'x': {
+            case 'o': {
                 uint64_t value;
                 if (long_arg) {
                     value = va_arg(args, uint64_t);
                 } else {
                     value = va_arg(args, uint32_t);
                 }
-                print_hex(buffer, size, &offset, value);
+                const char *prefix = "";
+                if (hash_flag && value != 0) {
+                    prefix = "0";
+                }
+                print_uint(buffer, size, &offset, value, 8, prefix, field_len, pad,
+                           left_justify, base_digits_lowercase);
+                break;
+            }
+            case 'p':
+            case 'x':
+            case 'X': {
+                uint64_t value;
+                bool pointer = ch == 'p';
+                if (pointer) {
+                    value = (uint64_t)va_arg(args, void *);
+                } else if (long_arg) {
+                    value = va_arg(args, uint64_t);
+                } else {
+                    value = va_arg(args, uint32_t);
+                }
+
+                const char *digits_set = base_digits_lowercase;
+                const char *prefix = "";
+                if (ch == 'X') {
+                    digits_set = base_digits_uppercase;
+                    if (hash_flag) {
+                        prefix = "0X";
+                    }
+                } else if (hash_flag) {
+                    prefix = "0x";
+                }
+
+                if (pointer && value == 0) {
+                    print_nstr_pad(buffer, size, &offset, NULL_REPR, NULL_REPR_LEN,
+                                   field_len, pad, left_justify);
+                } else {
+                    print_uint(buffer, size, &offset, value, 16, prefix, field_len, pad,
+                               left_justify, digits_set);
+                }
                 break;
             }
             default:


### PR DESCRIPTION
Some test code I have used
```c
    print("print() test suite\n");
    print("++++++++ - 8 characters\n");
    print("%d - '%s'\n", 69, "%d - '%s'\\n");
    print("%08d - '%s'\n", 69, "%08d - '%s'\\n");
    print("%8d - '%s'\n", 69, "%8d - '%s'\\n");
    print("%-8d - '%s'\n", 69, "%-8d - '%s'\\n");
    print("so what happens on padding overflow?\n");
    print("%d - '%s'\n", INT32_MAX, "%d - '%s'\\n");
    print("%08d - '%s'\n", INT32_MAX, "%08d - '%s'\\n");
    print("%8d - '%s'\n", INT32_MAX, "%8d - '%s'\\n");
    print("%-8d - '%s'\n", INT32_MAX, "%-8d - '%s'\\n");
    print("let's test printing limit values (didn't work previously)\n");
    print("INT64_MAX is %lld\n", INT64_MAX);
    print("INT64_MIN is %lld\n", INT64_MIN);
    print("okay, let's try hex now (with support for uppercase)\n");
    print("%016llx %016llX %08x %08X - '%s'\n", (unsigned long long)0xdeadbeef,
          (unsigned long long)0xcafebabe, 0xaba, 0xaba, "%016llx %016llX %08x %08X - '%s'\\n");
    print("%#016llx %#016llX %#08x %#08X - '%s'\n", (unsigned long long)0xdeadbeef,
          (unsigned long long)0xcafebabe, 0xaba, 0xaba, "%016llx %016llX %08x %08X - '%s'\\n");
    print("let's print a few strings\n");
    print("++++++++++++++++ - 16 characters\n");
    print("%s - '%s'\n", "default", "%s - '%s'\\n");
    print("%16s - '%s'\n", "default", "%16s - '%s'\\n");
    print("%-16s - '%s'\n", "default", "%-16s - '%s'\\n");
    print("%016s - '%s'\n", "default", "%016s - '%s'\\n");
    print("%s\n", NULL);
    print("% s| - empty strings are printed as spaces if \' \' modifier is used\n", "");
    print("signed modifier test\n");
    print("++++++++ ++++++++ - 8 characters, space, and 8 characters\n");
    print("%8d %8d\n", 123, -123);
    print("%-8d %-8d\n", 123, -123);
    print("%08d %08d\n", 123, -123);
    print("%%p can be used to print pointers\n");
    print("%p %p\n", 0xdeafbeef, 0);
```
Output:
```
print() test suite
++++++++ - 8 characters
69 - '%d - '%s'\n'
00000069 - '%08d - '%s'\n'
      69 - '%8d - '%s'\n'
69       - '%-8d - '%s'\n'
so what happens on padding overflow?
2147483647 - '%d - '%s'\n'
2147483647 - '%08d - '%s'\n'
2147483647 - '%8d - '%s'\n'
2147483647 - '%-8d - '%s'\n'
let's test printing limit values (didn't work previously)
INT64_MAX is 9223372036854775807
INT64_MIN is -9223372036854775808
okay, let's try hex now (with support for uppercase)
00000000deadbeef 00000000CAFEBABE 00000aba 00000ABA - '%016llx %016llX %08x %08X - '%s'\n'
0x000000deadbeef 0X000000CAFEBABE 0x000aba 0X000ABA - '%016llx %016llX %08x %08X - '%s'\n'
let's print a few strings
++++++++++++++++ - 16 characters
default - '%s - '%s'\n'
         default - '%16s - '%s'\n'
default          - '%-16s - '%s'\n'
         default - '%016s - '%s'\n'
(null)
 | - empty strings are printed as spaces if ' ' modifier is used
signed modifier test
++++++++ ++++++++ - 8 characters, space, and 8 characters
     123     -123
123      -123    
00000123 -0000123
%p can be used to print pointers
deafbeef (null)
```