### PR TITLE
Add ports and fixes/improvements around the kernel

### DIFF
--- a/kernel/fs/vfs/vfs.c
+++ b/kernel/fs/vfs/vfs.c
@@ -510,17 +510,12 @@ int syscall_openat(void *_, int dir_fdnum, const char *path, int flags, int mode
         goto cleanup;
     }
 
-    if (!S_ISREG(node->resource->stat.st_mode) && (flags & O_TRUNC) != 0) {
-        errno = EINVAL;
-        goto cleanup;
-    }
-
     struct f_descriptor *fd = fd_create_from_resource(node->resource, flags);
     if (fd == NULL) {
         goto cleanup;
     }
 
-    if ((flags & O_TRUNC) != 0) {
+    if ((flags & O_TRUNC) != 0 && S_ISREG(node->resource->stat.st_mode)) {
         node->resource->truncate(node->resource, fd->description, 0);
     }
 

--- a/kernel/lib/resource.h
+++ b/kernel/lib/resource.h
@@ -27,6 +27,7 @@ struct resource {
     int (*ioctl)(struct resource *this, struct f_description *description, uint64_t request, uint64_t arg);
     void *(*mmap)(struct resource *this, size_t file_page, int flags);
     bool (*unref)(struct resource *this, struct f_description *description);
+    bool (*ref)(struct resource *this, struct f_description *description);
     bool (*truncate)(struct resource *this, struct f_description *description, size_t length);
 };
 
@@ -49,7 +50,7 @@ void *resource_create(size_t size);
 void resource_free(struct resource *res);
 dev_t resource_create_dev_id(void);
 
-bool fdnum_close(struct process *proc, int fdnum);
+bool fdnum_close(struct process *proc, int fdnum, bool lock);
 int fdnum_create_from_fd(struct process *proc, struct f_descriptor *fd, int old_fdnum, bool specific);
 int fdnum_create_from_resource(struct process *proc, struct resource *res, int flags,
                                int old_fdnum, bool specific);

--- a/kernel/sched/sched.c
+++ b/kernel/sched/sched.c
@@ -714,7 +714,7 @@ int syscall_exit(void *_, int status) {
     thread->process = kernel_process;
 
     for (int i = 0; i < MAX_FDS; i++) {
-        fdnum_close(proc, i);
+        fdnum_close(proc, i, true);
     }
 
     if (proc->pid != -1) {

--- a/patches/ace-of-penguins/jinx-working-patch.patch
+++ b/patches/ace-of-penguins/jinx-working-patch.patch
@@ -1,0 +1,70 @@
+diff --git ace-of-penguins-clean/lib/Makefile.am ace-of-penguins-workdir/lib/Makefile.am
+index 2056424..e93f8bd 100644
+--- ace-of-penguins-clean/lib/Makefile.am
++++ ace-of-penguins-workdir/lib/Makefile.am
+@@ -6,7 +6,7 @@ noinst_HEADERS = cards.h
+ CLEANFILES = images.c images.d
+ 
+ INCLUDES = $(X_CFLAGS) @PDA@
+-AM_LDFLAGS = $(X_LIBS)
++AM_LDFLAGS = $(X_LIBS) -lpng -lz -lm
+ 
+ BUILD_CC = @BUILD_CC@
+ AR = @AR@
+diff --git ace-of-penguins-clean/lib/make-imglib.c ace-of-penguins-workdir/lib/make-imglib.c
+index 84cda12..dde0ffa 100644
+--- ace-of-penguins-clean/lib/make-imglib.c
++++ ace-of-penguins-workdir/lib/make-imglib.c
+@@ -86,7 +86,7 @@ scan_image_directory ()
+     png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, 0, 0, 0);
+     info_ptr = png_create_info_struct (png_ptr);
+ 
+-    if (setjmp (png_ptr->jmpbuf)) {
++    if (setjmp (png_jmpbuf(png_ptr))) {
+       fclose (f);
+       continue;
+     }
+diff --git ace-of-penguins-clean/lib/xwin.c ace-of-penguins-workdir/lib/xwin.c
+index e4bcca2..724be23 100644
+--- ace-of-penguins-clean/lib/xwin.c
++++ ace-of-penguins-workdir/lib/xwin.c
+@@ -55,7 +55,7 @@ OptionDesc xwin_options_list[] = {
+   { "-visual", OPTION_INTEGER, &visual_id },
+   { 0, 0, 0 }
+ };
+-OptionDesc *xwin_options = xwin_options_list;
++//OptionDesc *xwin_options = xwin_options_list;
+ 
+ Display *display=0;
+ int screen=0;
+@@ -89,10 +89,10 @@ int help_background;
+ /* Motif window hints */
+ typedef struct
+ {
+-  unsigned flags;
+-  unsigned functions;
+-  unsigned decorations;
+-  int inputMode;
++  unsigned long flags;
++  unsigned long functions;
++  unsigned long decorations;
++  long inputMode;
+ } PropMotifWmHints;
+ 
+ typedef PropMotifWmHints        PropMwmHints;
+@@ -841,13 +841,13 @@ build_image (image *src)
+   png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, 0, 0, 0);
+   info_ptr = png_create_info_struct (png_ptr);
+ 
+-  if (setjmp (png_ptr->jmpbuf)) {
++  if (setjmp (png_jmpbuf(png_ptr))) {
+     fprintf(stderr, "Invalid PNG image!\n");
+     return;
+   }
+ 
+   file_bytes = src->file_data;
+-  png_set_read_fn (png_ptr, (voidp)&file_bytes, (png_rw_ptr)png_reader);
++  png_set_read_fn (png_ptr, (void*)&file_bytes, (png_rw_ptr)png_reader);
+ 
+   png_read_info (png_ptr, info_ptr);
+ 

--- a/patches/neofetch/jinx-working-patch.patch
+++ b/patches/neofetch/jinx-working-patch.patch
@@ -1,0 +1,48 @@
+diff --git neofetch-clean/neofetch neofetch-workdir/neofetch
+index 1e4b564..4224c55 100755
+--- neofetch-clean/neofetch
++++ neofetch-workdir/neofetch
+@@ -929,6 +929,7 @@ get_os() {
+         AIX)      os=AIX ;;
+         IRIX*)    os=IRIX ;;
+         FreeMiNT) os=FreeMiNT ;;
++        Lyre)     os=Lyre ;;
+ 
+         Linux|GNU*)
+             os=Linux
+@@ -954,6 +955,7 @@ get_distro() {
+     [[ $distro ]] && return
+ 
+     case $os in
++    	Lyre) distro=Lyre ;;
+         Linux|BSD|MINIX)
+             if [[ -f /bedrock/etc/bedrock-release && $PATH == */bedrock/cross/* ]]; then
+                 case $distro_shorthand in
+@@ -5288,6 +5290,27 @@ get_distro_ascii() {
+     #
+     # $ascii_distro is the same as $distro.
+     case $(trim "$ascii_distro") in
++        "Lyre"*)
++            set_colors 4 1
++            read -rd '' ascii_data <<'EOF'
++${c1}
++########
++########
++########
++########
++########
++########
++########
++########
++########
++########
++########
++################
++################
++################
++################
++EOF
++	;;
+         "AIX"*)
+             set_colors 2 7
+             read -rd '' ascii_data <<'EOF'

--- a/recipes/ace-of-penguins
+++ b/recipes/ace-of-penguins
@@ -1,12 +1,16 @@
 name=ace-of-penguins
 from_source=ace-of-penguins
 revision=1
-imagedeps="meson ninja base-devel libpng"
-hostdeps="gcc binutils pkg-config"
-deps="mlibc libx11 libxpm libpng zlib"
+imagedeps="gcc libpng"
+hostdeps="gcc autoconf automake pkg-config libtool"
+deps="core-libs libx11 libxpm libpng zlib"
 
 configure() {
-    ${source_dir}/configure --prefix=${prefix} --host=x86_64-lyre
+    ${source_dir}/configure \
+        --sysconfdir=/etc \
+        --localstatedir=/var \
+        --prefix=${prefix} \
+        --host=x86_64-lyre
 }
 
 build() {
@@ -14,5 +18,5 @@ build() {
 }
 
 install() {
-    make DESTDIR=${dest_dir} install
+    DESTDIR="${dest_dir}" make install-strip
 }

--- a/recipes/ace-of-penguins
+++ b/recipes/ace-of-penguins
@@ -1,0 +1,18 @@
+name=ace-of-penguins
+from_source=ace-of-penguins
+revision=1
+imagedeps="meson ninja base-devel libpng"
+hostdeps="gcc binutils pkg-config"
+deps="mlibc libx11 libxpm libpng zlib"
+
+configure() {
+    ${source_dir}/configure --prefix=${prefix} --host=x86_64-lyre
+}
+
+build() {
+    make -j${parallelism}
+}
+
+install() {
+    make DESTDIR=${dest_dir} install
+}

--- a/recipes/neofetch
+++ b/recipes/neofetch
@@ -1,0 +1,17 @@
+name=neofetch
+from_source=neofetch
+revision=1
+rundeps="bash"
+
+configure() {	
+    true
+}
+
+build() {
+    true
+}
+
+install() {
+    mkdir -p "${dest_dir}"/usr/bin
+    cp -f "${source_dir}"/neofetch "${dest_dir}"/usr/bin/neofetch
+}

--- a/source-recipes/ace-of-penguins
+++ b/source-recipes/ace-of-penguins
@@ -1,6 +1,6 @@
 name=ace-of-penguins
 version=1.4
-tarball_url="https://www.delorie.com/store/ace/ace-1.4.tar.gz"
+tarball_url="https://www.delorie.com/store/ace/ace-${version}.tar.gz"
 tarball_blake2b=62d32bcada9a945d0a409757ca24c8c5c032e905528d56a51b95f82844c6c8057d39763016fa05015877f23313d842effeaaa362507bb049816d7cf6bdf01a1a
 hostdeps="autoconf automake xorg-macros pkg-config libtool"
 

--- a/source-recipes/ace-of-penguins
+++ b/source-recipes/ace-of-penguins
@@ -1,0 +1,9 @@
+name=ace-of-penguins
+version=1.4
+tarball_url="https://www.delorie.com/store/ace/ace-1.4.tar.gz"
+tarball_blake2b=62d32bcada9a945d0a409757ca24c8c5c032e905528d56a51b95f82844c6c8057d39763016fa05015877f23313d842effeaaa362507bb049816d7cf6bdf01a1a
+hostdeps="autoconf automake xorg-macros pkg-config libtool"
+
+regenerate() {
+    libtoolize -cfvi && autoreconf -fvi
+}

--- a/source-recipes/neofetch
+++ b/source-recipes/neofetch
@@ -1,0 +1,8 @@
+name=neofetch
+version=7.1.0
+tarball_url="https://github.com/dylanaraps/neofetch/archive/refs/tags/${version}.tar.gz"
+tarball_blake2b=32368d461835d95ba8203c560b2f6733594966cbaf809d877a46c08675284288565e3a21b14d94900dd66b778dc975339196f182732e2cd8bc1ccc9e6da6253e
+
+regenerate() {
+        true
+}


### PR DESCRIPTION
- Turn O_TRUNC into a no-op on special files instead of returning EINVAL
- Add a lock parameter to fdnum_close() to fix a deadlock
- Add a res->ref() function pointer to allow for more specific refcounting (such as on pipes)
- Increase pipe capacity from 4096 to PAGE_SIZE * 16
- Track writers and readers instead of using the resource refcount for pipes
- Add neofetch and ace of penguins port