### PR TITLE
VFS and PCI improvements

### DIFF
--- a/kernel/dev/pci.h
+++ b/kernel/dev/pci.h
@@ -57,6 +57,7 @@ struct pci_driver {
 extern uint32_t (*pci_read)(struct pci_device *, uint32_t, int);
 extern void (*pci_write)(struct pci_device *, uint32_t, uint32_t, int);
 
+bool pci_map_bar(struct pci_bar bar);
 void pci_set_privl(struct pci_device *d, uint16_t privilege);
 bool pci_setmask(struct pci_device *d, size_t index, bool masked);
 bool pci_enable_irq(struct pci_device *d, size_t index, int vec);

--- a/kernel/dev/storage/nvme/nvme.c
+++ b/kernel/dev/storage/nvme/nvme.c
@@ -653,6 +653,7 @@ static void nvme_initcontroller(struct pci_device *device) {
 
     ASSERT_MSG(bar.is_mmio, "PCI bar is not memory mapped!");
     ASSERT((PCI_READD(device, 0x10) & 0b111) == 0b100);
+    ASSERT(pci_map_bar(bar));
 
     controller_res->bar = (struct nvme_bar *)(bar.base);
     pci_set_privl(device, PCI_PRIV_MMIO | PCI_PRIV_BUSMASTER);

--- a/kernel/fs/ext2fs.c
+++ b/kernel/fs/ext2fs.c
@@ -1019,7 +1019,6 @@ static void ext2fs_populate(struct vfs_filesystem *_this, struct vfs_node *node)
 
         if (S_ISDIR(mode)) {
             vfs_create_dotentries(fnode, node); // set up for correct directory structure
-            ext2fs_populate((struct vfs_filesystem *)fs, fnode); // recurse filesystem
         }
 
         if (S_ISLNK(mode)) {
@@ -1156,8 +1155,6 @@ static struct vfs_node *ext2fs_mount(struct vfs_node *parent, const char *name, 
     resource->fs = new_fs;
 
     node->resource = (struct resource *)resource;
-
-    ext2fs_populate((struct vfs_filesystem *)new_fs, node); // recursively fill vfs with filesystem
 
     return node; // root node (will become child of parent)
 }


### PR DESCRIPTION
- Fix an issue where the size reported by the BAR struct was wrong
- Add a pci_map_bar function to map BARs that are beyond the identity maps
- Make it so that populate is called when walking through the filesystem in path2node(). Remove the recursive populate calls in ext2fs to account for it.